### PR TITLE
Add `clientId` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ Google's javascript library will be automatically referenced inside `<head>`. To
 var ENV = {
   // ...
   streetView: {
-    apiKey: 'API-KEY-HERE'
+    apiKey: 'API-KEY-HERE',
+    // or the clientId if using Maps for Work
+    // https://developers.google.com/maps/documentation/business/clientside/#client_id
+    clientId: 'CLIENT-ID-HERE'
   },
   // ...
 };

--- a/index.js
+++ b/index.js
@@ -7,10 +7,12 @@ module.exports = {
   contentFor: function(type, config) {
     if (type === 'head') {
       var config = config.streetView || {};
+
       if (config.include !== false) {
-        var apiKey = config.apiKey;
-        var keyParam = apiKey ? '?key=' + apiKey : '';
-        return '<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js' + keyParam + '"></script>';
+        var value = config.clientId || config.apiKey;
+        var type = config.clientId ? 'client' : 'key';
+
+        return '<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?' + type + '=' + value + '"></script>';
       }
     }
   }


### PR DESCRIPTION
This allows for using this addon for Google Maps for Work, which doesn't use an API Key.

See https://developers.google.com/maps/documentation/business/clientside/#client_id

Basically `clientId`, if set, overrides the `apiKey`.