### PR TITLE
Make sure position is updated

### DIFF
--- a/addon/components/street-view.js
+++ b/addon/components/street-view.js
@@ -64,7 +64,7 @@ export default Component.extend({
     }, panorama);
   },
 
-  updatePanoramaPosition: on('init', observer('lat', 'lng', function() {
+  updatePanoramaPosition: on('init', observer('lat', 'lng', 'panorama', function() {
     let lat = this.get('lat');
     let lng = this.get('lng');
     let panorama = this.get('panorama');


### PR DESCRIPTION
Basically in Safari `updatePanoramaPosition` is triggered before `didInsertElement` and doesn't have the `panorama` object, so I added it as an argument to observe and re-trigger on.